### PR TITLE
[CLOUDTRUST-2674] Add methods to get users details

### DIFF
--- a/keycloak-rest-api-extensions-tests/src/test/java/io/cloudtrust/keycloak/services/api/admin/RealmAdminResourceTest.java
+++ b/keycloak-rest-api-extensions-tests/src/test/java/io/cloudtrust/keycloak/services/api/admin/RealmAdminResourceTest.java
@@ -1,0 +1,36 @@
+package io.cloudtrust.keycloak.services.api.admin;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudtrust.keycloak.ApiTest;
+import org.hamcrest.collection.IsEmptyCollection;
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+public class RealmAdminResourceTest extends ApiTest {
+    private ObjectMapper mapper = new ObjectMapper();
+
+    private TypeReference<List<String>> lockedUsersTypeRef = new TypeReference<List<String>>() {
+    };
+    private TypeReference<Map<String, Integer>> usersAuthenticatorsTypeRef = new TypeReference<Map<String, Integer>>() {
+    };
+
+    @Test
+    public void testGetLockedUsers() throws IOException, URISyntaxException {
+        List<String> lockedUsers = mapper.readValue(callApi("admin/realms/test/locked-users"), lockedUsersTypeRef);
+        Assert.assertThat(lockedUsers, IsEmptyCollection.empty());
+    }
+
+    @Test
+    public void testGetAuthenticatorsCount() throws IOException, URISyntaxException {
+        Map<String, Integer> authenticators = mapper.readValue(callApi("admin/realms/test/authenticators-count"), usersAuthenticatorsTypeRef);
+        // Hard to check user ids as they are always changing
+        Assert.assertThat(authenticators, IsMapContaining.hasValue(1));
+    }
+}

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/services/resource/api/admin/RealmAdminResource.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/services/resource/api/admin/RealmAdminResource.java
@@ -1,13 +1,25 @@
 package io.cloudtrust.keycloak.services.resource.api.admin;
 
+import org.jboss.resteasy.annotations.cache.NoCache;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.keycloak.connections.jpa.JpaConnectionProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserLoginFailureModel;
 import org.keycloak.protocol.oidc.TokenManager;
 import org.keycloak.services.resources.admin.AdminEventBuilder;
 import org.keycloak.services.resources.admin.permissions.AdminPermissionEvaluator;
+import org.keycloak.services.resources.admin.permissions.UserPermissionEvaluator;
 
+import javax.persistence.EntityManager;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class RealmAdminResource extends org.keycloak.services.resources.admin.RealmAdminResource {
 
@@ -34,4 +46,42 @@ public class RealmAdminResource extends org.keycloak.services.resources.admin.Re
         return new StatisticsResource(session, auth);
     }
 
+    @Path("/locked-users")
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @SuppressWarnings("unchecked")
+    public List<String> getLockedUsers() {
+        UserPermissionEvaluator userPermissionEvaluator = auth.users();
+        userPermissionEvaluator.requireView();
+        userPermissionEvaluator.requireQuery();
+
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+        List<String> result = em.createQuery("select u.id from UserEntity u where u.realmId=:realmId and u.enabled=true")
+                .setParameter("realmId", realm.getId())
+                .getResultList();
+        // UserLoginFailures are stored in InfiniSpan so getUserLoginFailure(...) is supposed to be a fast operation
+        long now = System.currentTimeMillis() / 1000;
+        return result.stream().filter(userId -> {
+            UserLoginFailureModel loginFailure = session.sessions().getUserLoginFailure(realm, userId);
+            return loginFailure != null && now < loginFailure.getFailedLoginNotBefore();
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    @Path("/authenticators-count")
+    @GET
+    @NoCache
+    @Produces(MediaType.APPLICATION_JSON)
+    @SuppressWarnings("unchecked")
+    public Map<String, Long> getAuthenticatorsCount() {
+        UserPermissionEvaluator userPermissionEvaluator = auth.users();
+        userPermissionEvaluator.requireView();
+        userPermissionEvaluator.requireQuery();
+
+        EntityManager em = session.getProvider(JpaConnectionProvider.class).getEntityManager();
+        List<Object[]> result = em.createQuery("select u.id, count(*) from UserEntity u join u.credentials c where u.realmId=:realmId and u.enabled=true group by u.id")
+                .setParameter("realmId", realm.getId())
+                .getResultList();
+        return result.stream().collect(Collectors.toMap(o -> (String) o[0], o -> (Long) o[1]));
+    }
 }


### PR DESCRIPTION
(locked status, authenticators count)

Linked to :
* cloudtrust/keycloak-client#61
* cloudtrust/keycloak-bridge#229