### PR TITLE
[CLOUDTRUST-6445] Extend custom password provider with SSHA

### DIFF
--- a/keycloak-rest-api-extensions-tests/pom.xml
+++ b/keycloak-rest-api-extensions-tests/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>keycloak-rest-api-extensions-tests</artifactId>
-    <version>26.0.3-SNAPSHOT</version>
+    <version>26.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/keycloak-rest-api-extensions/pom.xml
+++ b/keycloak-rest-api-extensions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.cloudtrust</groupId>
         <artifactId>keycloak-rest-api-extensions-parent</artifactId>
-        <version>26.0.3-SNAPSHOT</version>
+        <version>26.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>keycloak-rest-api-extensions</artifactId>

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/AbstractSshaPasswordHashProvider.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/AbstractSshaPasswordHashProvider.java
@@ -1,0 +1,89 @@
+package io.cloudtrust.keycloak.credential;
+
+import com.google.common.primitives.Bytes;
+import org.keycloak.common.util.Base64;
+import org.keycloak.credential.hash.PasswordHashProvider;
+import org.keycloak.models.PasswordPolicy;
+import org.keycloak.models.credential.PasswordCredentialModel;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/**
+ * Abstract base class for Salted SHA password hash algorithms.
+ */
+public abstract class AbstractSshaPasswordHashProvider implements PasswordHashProvider {
+    private final String algorithm;
+    private final String prefix;
+    private final int hashLength;
+    private final String factoryId;
+
+    protected AbstractSshaPasswordHashProvider(String algorithm, String prefix, int hashLength, String factoryId) {
+        this.algorithm = algorithm;
+        this.prefix = prefix;
+        this.hashLength = hashLength;
+        this.factoryId = factoryId;
+    }
+
+    @Override
+    public boolean policyCheck(PasswordPolicy policy, PasswordCredentialModel credential) {
+        return policy != null && credential.getPasswordCredentialData().getAlgorithm().equals(factoryId);
+    }
+
+    @Override
+    public PasswordCredentialModel encodedCredential(String rawPassword, int iterations) {
+        byte[] salt = generateSalt();
+        byte[] toEncode;
+        try {
+            MessageDigest digest = MessageDigest.getInstance(algorithm);
+            byte[] hash = digest.digest(Bytes.concat(rawPassword.getBytes(), salt));
+
+            toEncode = Bytes.concat(hash, salt);
+            String value = prefix + Base64.encodeBytes(toEncode);
+
+            return PasswordCredentialModel.createFromValues(factoryId, salt, 1, value);
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean verify(String rawPassword, PasswordCredentialModel credential) {
+        if (!credential.getPasswordSecretData().getValue().startsWith(prefix)) {
+            // String is not properly formatted
+            return false;
+        }
+
+        try {
+            byte[] decodedValue = Base64.decode(credential.getPasswordSecretData().getValue().substring(prefix.length()));
+
+            // For verification, the salt contained in the PasswordSecretData object is ignored, we only retrieve it
+            // from the value
+            byte[] salt = Arrays.copyOfRange(decodedValue, hashLength, decodedValue.length);
+            MessageDigest digest = MessageDigest.getInstance(algorithm);
+            byte[] hash = digest.digest(Bytes.concat(rawPassword.getBytes(), salt));
+
+            byte[] result = Bytes.concat(hash, salt);
+            return Arrays.equals(result, decodedValue);
+        } catch (IOException | NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+
+    protected byte[] generateSalt() {
+        byte[] salt = new byte[32];
+        new SecureRandom().nextBytes(salt);
+        return salt;
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do
+    }
+}
+
+
+

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/AbstractSshaPasswordHashProviderFactory.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/AbstractSshaPasswordHashProviderFactory.java
@@ -1,0 +1,35 @@
+package io.cloudtrust.keycloak.credential;
+
+import org.keycloak.Config;
+import org.keycloak.credential.hash.PasswordHashProvider;
+import org.keycloak.credential.hash.PasswordHashProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Abstract base class for SSHA password hash provider factories.
+ */
+public abstract class AbstractSshaPasswordHashProviderFactory<T extends PasswordHashProvider> implements PasswordHashProviderFactory {
+
+    protected abstract T createProvider();
+
+    @Override
+    public PasswordHashProvider create(KeycloakSession session) {
+        return createProvider();
+    }
+    @Override
+    public void init(Config.Scope config) {
+        // Nothing to do
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // Nothing to do
+    }
+
+    @Override
+    public void close() {
+        // Nothing to do
+    }
+
+}

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha1PasswordHashProvider.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha1PasswordHashProvider.java
@@ -1,0 +1,13 @@
+package io.cloudtrust.keycloak.credential;
+
+/**
+ * Implementation of the Salted SHA1 password hash algorithm.
+ */
+public class Ssha1PasswordHashProvider extends AbstractSshaPasswordHashProvider {
+    private static final String SSHA1_PREFIX = "{SSHA}";
+    private static final int SSHA1_OUTPUT_BYTE_LENGTH = 20;
+
+    public Ssha1PasswordHashProvider() {
+        super("SHA-1", SSHA1_PREFIX, SSHA1_OUTPUT_BYTE_LENGTH, Ssha1PasswordHashProviderFactory.ID);
+    }
+}

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha1PasswordHashProviderFactory.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha1PasswordHashProviderFactory.java
@@ -1,0 +1,18 @@
+package io.cloudtrust.keycloak.credential;
+
+/**
+ * Provider factory for the Salted SHA1 password hash algorithm.
+ */
+public class Ssha1PasswordHashProviderFactory extends AbstractSshaPasswordHashProviderFactory<Ssha1PasswordHashProvider> {
+    public static final String ID = "ssha1";
+
+    @Override
+    public Ssha1PasswordHashProvider createProvider() {
+        return new Ssha1PasswordHashProvider();
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+}

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha256PasswordHashProvider.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha256PasswordHashProvider.java
@@ -1,73 +1,13 @@
 package io.cloudtrust.keycloak.credential;
 
-import com.google.common.primitives.Bytes;
-import org.keycloak.common.util.Base64;
-import org.keycloak.credential.hash.PasswordHashProvider;
-import org.keycloak.models.PasswordPolicy;
-import org.keycloak.models.credential.PasswordCredentialModel;
-
-import java.io.IOException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Arrays;
-
 /**
  * Implementation of the Salted SHA256 password hash algorithm.
  */
-public class Ssha256PasswordHashProvider implements PasswordHashProvider {
+public class Ssha256PasswordHashProvider extends AbstractSshaPasswordHashProvider {
     private static final String SSHA256_PREFIX = "{SSHA256}";
+    private static final int SSHA256_OUTPUT_BYTE_LENGTH = 32;
 
-    @Override
-    public boolean policyCheck(PasswordPolicy policy, PasswordCredentialModel credential) {
-        return policy != null && credential.getPasswordCredentialData().getAlgorithm().equals(Ssha256PasswordHashProviderFactory.ID);
-    }
-
-    @Override
-    public PasswordCredentialModel encodedCredential(String rawPassword, int iterations) {
-        byte[] salt = new byte[32];
-        SecureRandom random = new SecureRandom();
-        random.nextBytes(salt);
-
-        byte[] toEncode;
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(Bytes.concat(rawPassword.getBytes(), salt));
-
-            toEncode = Bytes.concat(hash, salt);
-            String value = SSHA256_PREFIX + Base64.encodeBytes(toEncode);
-
-            return PasswordCredentialModel.createFromValues(Ssha256PasswordHashProviderFactory.ID, salt, 1, value);
-        } catch (NoSuchAlgorithmException e) {
-            return null;
-        }
-    }
-
-    @Override
-    public boolean verify(String rawPassword, PasswordCredentialModel credential) {
-        if (!credential.getPasswordSecretData().getValue().startsWith(SSHA256_PREFIX)) {
-            // String is not properly formatted
-            return false;
-        }
-
-        try {
-            byte[] decodedValue = Base64.decode(credential.getPasswordSecretData().getValue().substring(SSHA256_PREFIX.length()));
-
-            // For verification, the salt contained in the PasswordSecretData object is ignored, we only retrieve it
-            // from the value
-            byte[] salt = Arrays.copyOfRange(decodedValue, 32, decodedValue.length);
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(Bytes.concat(rawPassword.getBytes(), salt));
-
-            byte[] result = Bytes.concat(hash, salt);
-            return Arrays.equals(result, decodedValue);
-        } catch (IOException | NoSuchAlgorithmException e) {
-            return false;
-        }
-    }
-
-    @Override
-    public void close() {
-        // Nothing to do
+    public Ssha256PasswordHashProvider() {
+        super("SHA-256", SSHA256_PREFIX, SSHA256_OUTPUT_BYTE_LENGTH, Ssha256PasswordHashProviderFactory.ID);
     }
 }

--- a/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha256PasswordHashProviderFactory.java
+++ b/keycloak-rest-api-extensions/src/main/java/io/cloudtrust/keycloak/credential/Ssha256PasswordHashProviderFactory.java
@@ -1,35 +1,14 @@
 package io.cloudtrust.keycloak.credential;
 
-import org.keycloak.Config;
-import org.keycloak.credential.hash.PasswordHashProvider;
-import org.keycloak.credential.hash.PasswordHashProviderFactory;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.KeycloakSessionFactory;
-
 /**
  * Provider factory for the Salted SHA256 password hash algorithm.
  */
-public class Ssha256PasswordHashProviderFactory implements PasswordHashProviderFactory {
+public class Ssha256PasswordHashProviderFactory extends AbstractSshaPasswordHashProviderFactory<Ssha256PasswordHashProvider> {
     public static final String ID = "ssha256";
 
     @Override
-    public PasswordHashProvider create(KeycloakSession session) {
+    public Ssha256PasswordHashProvider createProvider() {
         return new Ssha256PasswordHashProvider();
-    }
-
-    @Override
-    public void init(Config.Scope config) {
-        // Nothing to do
-    }
-
-    @Override
-    public void postInit(KeycloakSessionFactory factory) {
-        // Nothing to do
-    }
-
-    @Override
-    public void close() {
-        // Nothing to do
     }
 
     @Override

--- a/keycloak-rest-api-extensions/src/main/resources/META-INF/services/org.keycloak.credential.hash.PasswordHashProviderFactory
+++ b/keycloak-rest-api-extensions/src/main/resources/META-INF/services/org.keycloak.credential.hash.PasswordHashProviderFactory
@@ -1,1 +1,2 @@
+io.cloudtrust.keycloak.credential.Ssha1PasswordHashProviderFactory
 io.cloudtrust.keycloak.credential.Ssha256PasswordHashProviderFactory

--- a/keycloak-rest-api-extensions/src/test/java/io/cloudtrust/keycloak/credential/Ssha1PasswordHashProviderTest.java
+++ b/keycloak-rest-api-extensions/src/test/java/io/cloudtrust/keycloak/credential/Ssha1PasswordHashProviderTest.java
@@ -1,0 +1,34 @@
+package io.cloudtrust.keycloak.credential;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.credential.PasswordCredentialModel;
+import org.keycloak.models.credential.dto.PasswordCredentialData;
+import org.keycloak.models.credential.dto.PasswordSecretData;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class Ssha1PasswordHashProviderTest {
+
+    @Test
+    void encodeVerifyWorks() {
+        Ssha1PasswordHashProvider hashProvider = new Ssha1PasswordHashProvider();
+        PasswordCredentialModel encodedCredential = hashProvider.encodedCredential("password", 1);
+
+        assertThat(hashProvider.verify("password", encodedCredential), is(true));
+        assertThat(hashProvider.verify("wrong-password", encodedCredential), is(false));
+    }
+
+    @Test
+    void verifyWorks() {
+        String rawPassword = "Blub1234!Blub";
+
+        Ssha1PasswordHashProvider hashProvider = new Ssha1PasswordHashProvider();
+        PasswordCredentialData credentialData = new PasswordCredentialData(1, "SSHA1");
+        byte[] salt = {};
+        PasswordSecretData secretData = new PasswordSecretData("{SSHA}qlZRsgVNc96hopKzDPK15gt12n2ITkcuB8PDp1VR", salt);
+        PasswordCredentialModel result = PasswordCredentialModel.createFromValues(credentialData, secretData);
+
+        assertThat(hashProvider.verify(rawPassword, result), is(true));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>keycloak-rest-api-extensions-parent</artifactId>
-    <version>26.0.3-SNAPSHOT</version>
+    <version>26.1.0-SNAPSHOT</version>
     <description>Parent for rest API extensions</description>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Similar to what was done by @Xelowak for [SSHA-256](https://github.com/cloudtrust/keycloak-rest-api-extensions/pull/80)